### PR TITLE
Feature/report

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,9 @@
             android:name=".presentation.ui.researchlist.ResearchListActivity"
             android:exported="true" />
         <activity
+            android:name=".presentation.ui.report.ReportActivity"
+            android:exported="true" />
+        <activity
             android:name=".presentation.ui.main.MainActivity"
             android:exported="true" />
         <activity

--- a/app/src/main/java/com/doctor/yumyum/presentation/adapter/BindingAdapter.kt
+++ b/app/src/main/java/com/doctor/yumyum/presentation/adapter/BindingAdapter.kt
@@ -1,18 +1,25 @@
 package com.doctor.yumyum.presentation.adapter
 
-import android.util.Log
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.databinding.BindingAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.doctor.yumyum.R
 
 @BindingAdapter("bind_tagList")
-fun bindTagList(rvTagList: RecyclerView, tagList : ArrayList<String>?){
+fun bindTagList(rvTagList: RecyclerView, tagList: ArrayList<String>?) {
     tagList?.run {
         ((rvTagList.adapter) as WriteTagAdapter).updateTagList(this)
     }
 }
 
 @BindingAdapter("bind_tagItem")
-fun bindTagItem(tvTagItem: TextView, tagItem : String){
-    tvTagItem.text= "#$tagItem"
+fun bindTagItem(tvTagItem: TextView, tagItem: String) {
+    tvTagItem.text = "#$tagItem"
+}
+
+@BindingAdapter("bind_startCompat")
+fun bindStartCompat(textView: TextView, condition: Boolean) {
+    val src = if (condition) ContextCompat.getDrawable(textView.context, R.drawable.ic_report_selected) else ContextCompat.getDrawable(textView.context, R.drawable.ic_report_unselected)
+    textView.setCompoundDrawablesWithIntrinsicBounds(src, null, null, null)
 }

--- a/app/src/main/java/com/doctor/yumyum/presentation/ui/login/ErrorDialog.kt
+++ b/app/src/main/java/com/doctor/yumyum/presentation/ui/login/ErrorDialog.kt
@@ -1,6 +1,5 @@
 package com.doctor.yumyum.presentation.ui.login
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -9,18 +8,14 @@ import com.doctor.yumyum.R
 import com.doctor.yumyum.common.base.BaseDialog
 import com.doctor.yumyum.databinding.DialogErrorBinding
 
-
-class ErrorDialog :BaseDialog<DialogErrorBinding>(R.layout.dialog_error){
+class ErrorDialog : BaseDialog<DialogErrorBinding>(R.layout.dialog_error) {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         super.onCreateView(inflater, container, savedInstanceState)
-        binding.errorBtn.setOnClickListener {
-            val loginIntent = Intent(this.context, LoginActivity::class.java)
-            startActivity(loginIntent)
-        }
+        binding.errorBtn.setOnClickListener { dismiss() }
         return binding.root
     }
 }

--- a/app/src/main/java/com/doctor/yumyum/presentation/ui/main/ResearchRecipeFragment.kt
+++ b/app/src/main/java/com/doctor/yumyum/presentation/ui/main/ResearchRecipeFragment.kt
@@ -11,6 +11,7 @@ import com.doctor.yumyum.R
 import com.doctor.yumyum.common.base.BaseFragment
 import com.doctor.yumyum.databinding.FragmentResearchRecipeBinding
 import com.doctor.yumyum.presentation.adapter.ResearchBrandAdapter
+import com.doctor.yumyum.presentation.ui.login.ErrorDialog
 import com.doctor.yumyum.presentation.ui.recipedetail.RecipeMenuDialog
 import com.doctor.yumyum.presentation.ui.researchlist.ResearchListActivity
 import com.doctor.yumyum.presentation.viewmodel.ResearchRecipeViewModel
@@ -81,6 +82,9 @@ class ResearchRecipeFragment :
 
         viewModel.mode.observe(viewLifecycleOwner) { mode ->
             changeMode(mode)
+        }
+        viewModel.errorState.observe(viewLifecycleOwner) { errorState ->
+            if (errorState) ErrorDialog().show(parentFragmentManager, "ResearchRecipeFragment")
         }
 
         // 주간 랭킹 리스트 조회

--- a/app/src/main/java/com/doctor/yumyum/presentation/ui/main/ResearchRecipeFragment.kt
+++ b/app/src/main/java/com/doctor/yumyum/presentation/ui/main/ResearchRecipeFragment.kt
@@ -11,6 +11,7 @@ import com.doctor.yumyum.R
 import com.doctor.yumyum.common.base.BaseFragment
 import com.doctor.yumyum.databinding.FragmentResearchRecipeBinding
 import com.doctor.yumyum.presentation.adapter.ResearchBrandAdapter
+import com.doctor.yumyum.presentation.ui.recipedetail.RecipeMenuDialog
 import com.doctor.yumyum.presentation.ui.researchlist.ResearchListActivity
 import com.doctor.yumyum.presentation.viewmodel.ResearchRecipeViewModel
 import kotlinx.coroutines.CoroutineScope
@@ -69,6 +70,10 @@ class ResearchRecipeFragment :
             val intent = Intent(context, ResearchListActivity::class.java)
             intent.putExtra(getString(R.string.common_brand_en), it)
             startActivity(intent)
+        }
+        //TODO: 레시피 상세 화면으로 이동
+        binding.researchRecipeTvRanking.setOnClickListener {
+            RecipeMenuDialog().show(parentFragmentManager, "RecipeMenuDialog")
         }
         binding.researchRecipeRecyclerviewBrand.adapter = brandRecyclerAdapter
         brandRecyclerAdapter.setBrandList(beverageBrandList)

--- a/app/src/main/java/com/doctor/yumyum/presentation/ui/recipedetail/RecipeMenuDialog.kt
+++ b/app/src/main/java/com/doctor/yumyum/presentation/ui/recipedetail/RecipeMenuDialog.kt
@@ -1,0 +1,29 @@
+package com.doctor.yumyum.presentation.ui.recipedetail
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.doctor.yumyum.R
+import com.doctor.yumyum.common.base.BaseDialog
+import com.doctor.yumyum.databinding.DialogRecipeMenuBinding
+import com.doctor.yumyum.presentation.ui.report.ReportActivity
+
+class RecipeMenuDialog: BaseDialog<DialogRecipeMenuBinding>(R.layout.dialog_recipe_menu) {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        super.onCreateView(inflater, container, savedInstanceState)
+
+        binding.recipeMenuTvReport.setOnClickListener {
+            val intent = Intent(this.context, ReportActivity::class.java)
+            //TODO: 신고하기에 필요한 데이터 넘기기 ex) recipe id
+            startActivity(intent)
+            dismiss()
+        }
+        return binding.root
+    }
+}

--- a/app/src/main/java/com/doctor/yumyum/presentation/ui/report/ReportActivity.kt
+++ b/app/src/main/java/com/doctor/yumyum/presentation/ui/report/ReportActivity.kt
@@ -1,0 +1,25 @@
+package com.doctor.yumyum.presentation.ui.report
+
+import android.os.Bundle
+import androidx.lifecycle.ViewModelProvider
+import com.doctor.yumyum.R
+import com.doctor.yumyum.common.base.BaseActivity
+import com.doctor.yumyum.databinding.ActivityReportBinding
+
+class ReportActivity : BaseActivity<ActivityReportBinding>(R.layout.activity_report) {
+
+    private val viewModel by lazy {
+        ViewModelProvider(
+            this,
+            ViewModelProvider.NewInstanceFactory()
+        )[ReportViewModel::class.java]
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        binding.lifecycleOwner = this
+        binding.viewModel = viewModel
+        binding.reportToolbar.appbarIbBack.setOnClickListener { finish() }
+    }
+}

--- a/app/src/main/java/com/doctor/yumyum/presentation/ui/report/ReportViewModel.kt
+++ b/app/src/main/java/com/doctor/yumyum/presentation/ui/report/ReportViewModel.kt
@@ -1,0 +1,23 @@
+package com.doctor.yumyum.presentation.ui.report
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.doctor.yumyum.common.base.BaseViewModel
+
+class ReportViewModel: BaseViewModel() {
+    private val _reportType: MutableLiveData<Int> = MutableLiveData(REASON_DUPLICATE)
+    val reportType: LiveData<Int> get() = _reportType
+
+    fun setReportType(type: Int) {
+        _reportType.value = type
+    }
+
+    companion object {
+        const val REASON_DUPLICATE = 1
+        const val REASON_ADVERTISING = 2
+        const val REASON_IRRELEVANT = 3
+        const val REASON_HARMFUL = 4
+        const val REASON_WRONG = 5
+        const val REASON_ETC = 6
+    }
+}

--- a/app/src/main/java/com/doctor/yumyum/presentation/viewmodel/ResearchRecipeViewModel.kt
+++ b/app/src/main/java/com/doctor/yumyum/presentation/viewmodel/ResearchRecipeViewModel.kt
@@ -15,6 +15,8 @@ class ResearchRecipeViewModel : BaseViewModel() {
     private val repository = MainRepositoryImpl()
     private val _rankRecipes: MutableLiveData<List<RankRecipe>> = MutableLiveData()
     val rankRecipes: LiveData<List<RankRecipe>> get() = _rankRecipes
+    private val _errorState: MutableLiveData<Boolean> = MutableLiveData(false)
+    val errorState: LiveData<Boolean> get() = _errorState
 
     @SuppressLint("SupportAnnotationUsage")
     @StringRes
@@ -31,11 +33,15 @@ class ResearchRecipeViewModel : BaseViewModel() {
     }
 
     suspend fun getRankRecipe(categoryName: String, top: Int, rankDatePeriod: Int) {
-        val response: Response<RankRecipeResponse> =
-            repository.getRecipeRank(categoryName, top, rankDatePeriod)
+        try {
+            val response: Response<RankRecipeResponse> =
+                repository.getRecipeRank(categoryName, top, rankDatePeriod)
 
-        if (response.isSuccessful) {
-            _rankRecipes.postValue(response.body()?.topRankingFoods)
+            if (response.isSuccessful) {
+                _rankRecipes.postValue(response.body()?.topRankingFoods)
+            }
+        } catch (e: Exception) {
+            _errorState.postValue(true)
         }
     }
 }

--- a/app/src/main/res/drawable/ic_report_selected.xml
+++ b/app/src/main/res/drawable/ic_report_selected.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="34dp"
+    android:viewportWidth="36"
+    android:viewportHeight="34">
+  <path
+      android:pathData="M18,17m-12,0a12,12 0,1 1,24 0a12,12 0,1 1,-24 0"
+      android:fillColor="#ED6B2D"/>
+  <path
+      android:pathData="M18,17m-5,0a5,5 0,1 1,10 0a5,5 0,1 1,-10 0"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/app/src/main/res/drawable/ic_report_unselected.xml
+++ b/app/src/main/res/drawable/ic_report_unselected.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="34dp"
+    android:viewportWidth="36"
+    android:viewportHeight="34">
+  <path
+      android:pathData="M6,5h24v24h-24z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M18,17m-11,0a11,11 0,1 1,22 0a11,11 0,1 1,-22 0"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#D9D9D9"/>
+</vector>

--- a/app/src/main/res/layout/activity_report.xml
+++ b/app/src/main/res/layout/activity_report.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.doctor.yumyum.presentation.ui.report.ReportViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.ui.report.ReportActivity">
+
+        <include
+            android:id="@+id/report_toolbar"
+            layout="@layout/layout_appbar"
+            android:layout_width="match_parent"
+            android:layout_height="40dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:main="@{@string/report_title}" />
+
+        <TextView
+            android:id="@+id/report_tv_title"
+            style="@style/font_h2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="24dp"
+            android:layout_marginTop="30dp"
+            android:text="@string/report_select_reason"
+            android:textColor="@color/black"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/report_toolbar" />
+
+        <TextView
+            android:id="@+id/report_tv_reason_duplicate"
+            style="@style/font_body1_regular"
+            bind_startCompat="@{viewModel.reportType == viewModel.REASON_DUPLICATE}"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="21dp"
+            android:drawablePadding="6dp"
+            android:gravity="center_vertical"
+            android:onClick="@{() -> viewModel.setReportType(viewModel.REASON_DUPLICATE)}"
+            android:text="@string/report_reason_duplicate"
+            android:textColor="@color/black"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/report_tv_title"
+            tools:drawableStart="@drawable/ic_report_selected" />
+
+        <TextView
+            android:id="@+id/report_tv_reason_advertising"
+            style="@style/font_body1_regular"
+            bind_startCompat="@{viewModel.reportType == viewModel.REASON_ADVERTISING}"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="8dp"
+            android:drawablePadding="6dp"
+            android:gravity="center_vertical"
+            android:onClick="@{() -> viewModel.setReportType(viewModel.REASON_ADVERTISING)}"
+            android:text="@string/report_reason_advertising"
+            android:textColor="@color/black"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/report_tv_reason_duplicate"
+            tools:drawableStart="@drawable/ic_report_unselected" />
+
+        <TextView
+            android:id="@+id/report_tv_reason_irrelevant"
+            style="@style/font_body1_regular"
+            bind_startCompat="@{viewModel.reportType == viewModel.REASON_IRRELEVANT}"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="8dp"
+            android:drawablePadding="6dp"
+            android:gravity="center_vertical"
+            android:onClick="@{() -> viewModel.setReportType(viewModel.REASON_IRRELEVANT)}"
+            android:text="@string/report_reason_irrelevant"
+            android:textColor="@color/black"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/report_tv_reason_advertising"
+            tools:drawableStart="@drawable/ic_report_unselected" />
+
+        <TextView
+            android:id="@+id/report_tv_reason_harmful"
+            style="@style/font_body1_regular"
+            bind_startCompat="@{viewModel.reportType == viewModel.REASON_HARMFUL}"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="8dp"
+            android:drawablePadding="6dp"
+            android:gravity="center_vertical"
+            android:onClick="@{() -> viewModel.setReportType(viewModel.REASON_HARMFUL)}"
+            android:text="@string/report_reason_harmful"
+            android:textColor="@color/black"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/report_tv_reason_irrelevant"
+            tools:drawableStart="@drawable/ic_report_unselected" />
+
+        <TextView
+            android:id="@+id/report_tv_reason_wrong"
+            style="@style/font_body1_regular"
+            bind_startCompat="@{viewModel.reportType == viewModel.REASON_WRONG}"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="8dp"
+            android:drawablePadding="6dp"
+            android:gravity="center_vertical"
+            android:onClick="@{() -> viewModel.setReportType(viewModel.REASON_WRONG)}"
+            android:text="@string/report_reason_wrong"
+            android:textColor="@color/black"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/report_tv_reason_harmful"
+            tools:drawableStart="@drawable/ic_report_unselected" />
+
+        <TextView
+            android:id="@+id/report_tv_reason_etc"
+            style="@style/font_body1_regular"
+            bind_startCompat="@{viewModel.reportType == viewModel.REASON_ETC}"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="8dp"
+            android:drawablePadding="6dp"
+            android:gravity="center_vertical"
+            android:onClick="@{() -> viewModel.setReportType(viewModel.REASON_ETC)}"
+            android:text="@string/common_etc"
+            android:textColor="@color/black"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/report_tv_reason_wrong"
+            tools:drawableStart="@drawable/ic_report_unselected" />
+
+        <TextView
+            android:id="@+id/report_tv_report"
+            style="@style/font_subtitle_medium"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginBottom="20dp"
+            android:background="@drawable/bg_bottom_btn"
+            android:gravity="center"
+            android:paddingVertical="16dp"
+            android:text="@string/report"
+            android:textColor="@color/white"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/activity_write_tag.xml
+++ b/app/src/main/res/layout/activity_write_tag.xml
@@ -126,7 +126,7 @@
                 tools:listitem="@layout/item_input_ingredient" />
 
             <TextView
-                android:onClick="@{() -> tagActivity.removeClickListener()}"
+                android:onClick="@{() -> tagActivity.changeModeClickListener()}"
                 android:id="@+id/write_tag_tv_remove"
                 style="@style/font_body1_regular"
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/dialog_recipe_menu.xml
+++ b/app/src/main/res/layout/dialog_recipe_menu.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_dialog">
+
+        <TextView
+            android:id="@+id/recipe_menu_tv_report"
+            style="@style/font_body1_medium"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:paddingVertical="19dp"
+            android:text="@string/report_title"
+            android:textColor="@color/main_orange"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <View
+            android:id="@+id/recipe_menu_line"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:background="@color/light_gray"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/recipe_menu_tv_report" />
+
+        <TextView
+            android:id="@+id/recipe_menu_tv_share"
+            style="@style/font_body1_medium"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:paddingVertical="19dp"
+            android:text="@string/share_title"
+            android:textColor="@color/dark_gray"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/recipe_menu_line" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/fragment_write_second.xml
+++ b/app/src/main/res/layout/fragment_write_second.xml
@@ -75,7 +75,7 @@
             app:layout_constraintTop_toBottomOf="@+id/write_second_view2" />
 
         <androidx.appcompat.widget.AppCompatImageButton
-            android:visibility="@{write2ViewModel.addListLiveData.size() == 0 ? View.VISIBLE : View.INVISIBLE}"
+            android:visibility="@{secondViewModel.addTagList.size() == 0 ? View.VISIBLE : View.INVISIBLE}"
             android:id="@+id/write_second_btn_add"
             android:layout_width="22dp"
             android:layout_height="22dp"
@@ -93,8 +93,8 @@
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             android:layout_marginTop="12dp"
             app:layout_constraintTop_toBottomOf="@id/write_second_tv_guide_add"
-            android:visibility="@{write2ViewModel.addListLiveData.size() == 0 ? View.INVISIBLE : View.VISIBLE}"
-            bind_tagList="@{write2ViewModel.addListLiveData}"/>
+            android:visibility="@{secondViewModel.addTagList.size() == 0 ? View.INVISIBLE : View.VISIBLE}"
+            bind_tagList="@{secondViewModel.addTagList}"/>
 
         <TextView
             android:id="@+id/write_second_tv_guide_minus"
@@ -109,7 +109,7 @@
 
 
         <androidx.appcompat.widget.AppCompatImageButton
-            android:visibility="@{write2ViewModel.minusListLiveData.size() == 0 ? View.VISIBLE : View.INVISIBLE}"
+            android:visibility="@{secondViewModel.minusTagList.size() == 0 ? View.VISIBLE : View.INVISIBLE}"
             android:id="@+id/write_second_btn_minus"
             android:layout_width="22dp"
             android:layout_height="22dp"
@@ -127,8 +127,8 @@
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             android:layout_marginTop="12dp"
             app:layout_constraintTop_toBottomOf="@id/write_second_tv_guide_minus"
-            android:visibility="@{write2ViewModel.minusListLiveData.size() == 0 ? View.INVISIBLE : View.VISIBLE}"
-            bind_tagList="@{write2ViewModel.minusListLiveData}"/>
+            android:visibility="@{secondViewModel.minusTagList.size() == 0 ? View.INVISIBLE : View.VISIBLE}"
+            bind_tagList="@{secondViewModel.minusTagList}"/>
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/write_second_btn_next"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,4 +131,8 @@
     <string name="report_reason_harmful">가학적이나 유해한 내용을 게시하였습니다.</string>
     <string name="report_reason_wrong">잘못된 사실을 게시하였습니다.</string>
 
+    <!-- 공유하기 -->
+    <string name="share">공유</string>
+    <string name="share_title">공유하기</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,5 +121,14 @@
     <string name="research_list_search_with_hashtag">해시태그로 검색</string>
     <string name="research_list_ib_hashtag_reset">해시태그 삭제 버튼</string>
 
+    <!-- 신고하기 -->
+    <string name="report">신고</string>
+    <string name="report_title">신고하기</string>
+    <string name="report_select_reason">신고사유를 선택해주세요</string>
+    <string name="report_reason_duplicate">중복된 레시피를 게시하였습니다.</string>
+    <string name="report_reason_advertising">광고성 레시피를 게시하였습니다.</string>
+    <string name="report_reason_irrelevant">레시피와 관련없는 내용을 게시하였습니다.</string>
+    <string name="report_reason_harmful">가학적이나 유해한 내용을 게시하였습니다.</string>
+    <string name="report_reason_wrong">잘못된 사실을 게시하였습니다.</string>
 
 </resources>


### PR DESCRIPTION
## 무슨 기능인가요?
- 신고하기 화면 구현

## 화면
> 신고하기 다이얼로그, 화면

<img width="40%" src="https://user-images.githubusercontent.com/40855422/145700084-83ac26be-f6a2-46d5-ba5e-ac63ebaf85ec.png"/> <img width="40%" src="https://user-images.githubusercontent.com/40855422/145700087-67d9d491-90b9-4f17-8e4d-2ff95fa649df.png"/>

> 주간랭킹 서버 연결 오류 예외처리

<img width="40%" src="https://user-images.githubusercontent.com/40855422/145700076-19851a97-8704-4957-8fb1-137c2a0da50a.png"/>

## 구체적인 작업 내용
- 신고하기/공유하기 다이얼로그를 추가했습니다. (레시피 상세 화면으로 이동 예정)
- 신고하기 화면을 구현했습니다.
- 주간랭킹 데이터 조회시 서버 연결 오류 예외처리를 추가했습니다.
  - @junieberry ErrorDialog의 확인 버튼 클릭 시 로그인화면으로 이동하던 것을 삭제하고 다이얼로그만 dismiss 하도록 수정했습니다.
  - 로그인 실패시 로그인 화면이 추가적으로 계속 생성되는 것을 없애기 위해 + 재사용성을 높이기 위해 변경한 것인데 꼭 필요한 로직이라면 다시 돌려놓겠습니다.
- xml에서 데이터바인딩 시 변수명 불일치로 발생하는 오류를 수정했습니다.

## 기타

## Close Issue
close #39 
