### PR TITLE
Design/research recipe layout

### DIFF
--- a/app/src/main/java/com/doctor/yumyum/presentation/adapter/RankAdapter.kt
+++ b/app/src/main/java/com/doctor/yumyum/presentation/adapter/RankAdapter.kt
@@ -1,9 +1,9 @@
 package com.doctor.yumyum.presentation.adapter
 
 import android.annotation.SuppressLint
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View.INVISIBLE
+import android.view.View.VISIBLE
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
@@ -33,6 +33,7 @@ class RankAdapter(private val itemClickListener: (Int) -> Unit) :
                     .into(binding.researchRankingIvRecipe)
             }
 
+            binding.researchRankingIvRank.visibility = VISIBLE
             when (adapterPosition) {
                 0 -> binding.researchRankingIvRank.setImageResource(R.drawable.ic_gold_medal)
                 1 -> binding.researchRankingIvRank.setImageResource(R.drawable.ic_silver_medal)

--- a/app/src/main/java/com/doctor/yumyum/presentation/adapter/RankAdapter.kt
+++ b/app/src/main/java/com/doctor/yumyum/presentation/adapter/RankAdapter.kt
@@ -30,6 +30,7 @@ class RankAdapter(private val itemClickListener: (Int) -> Unit) :
                 Glide
                     .with(binding.researchRankingIvRecipe)
                     .load(recipe.foodImages[0].imageUrl)
+                    .placeholder(R.drawable.ic_loading_image)
                     .into(binding.researchRankingIvRecipe)
             }
 

--- a/app/src/main/java/com/doctor/yumyum/presentation/adapter/ResearchListAdapter.kt
+++ b/app/src/main/java/com/doctor/yumyum/presentation/adapter/ResearchListAdapter.kt
@@ -33,6 +33,7 @@ class ResearchListAdapter(
                 Glide
                     .with(binding.itemResearchRecipeIvImage)
                     .load(recipe.foodImages[0].imageUrl)
+                    .placeholder(R.drawable.ic_loading_image)
                     .into(binding.itemResearchRecipeIvImage)
             }
         }

--- a/app/src/main/res/layout/fragment_research_recipe.xml
+++ b/app/src/main/res/layout/fragment_research_recipe.xml
@@ -60,7 +60,7 @@
             android:background="#F8F8F8"
             app:layout_constraintTop_toBottomOf="@id/research_recipe_cl_appbar" />
 
-        <ScrollView
+        <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
             android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -153,6 +153,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="15dp"
+                    android:overScrollMode="never"
                     android:visibility="@{viewModel.rankRecipes.size() == 0 ? View.GONE : View.VISIBLE}"
                     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     app:layout_constraintTop_toBottomOf="@id/research_recipe_tv_ranking"
@@ -160,7 +161,7 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
-        </ScrollView>
+        </androidx.core.widget.NestedScrollView>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/item_research_ranking.xml
+++ b/app/src/main/res/layout/item_research_ranking.xml
@@ -44,8 +44,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/common_recipe_image"
-                android:scaleType="centerCrop"
-                android:src="@color/black" />
+                android:scaleType="center"
+                android:background="@color/light_gray"
+                android:src="@drawable/ic_loading_image" />
 
         </androidx.cardview.widget.CardView>
 

--- a/app/src/main/res/layout/item_research_recipe.xml
+++ b/app/src/main/res/layout/item_research_recipe.xml
@@ -23,9 +23,10 @@
                 android:id="@+id/item_research_recipe_iv_image"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:background="@color/light_gray"
                 android:contentDescription="@string/common_recipe_image"
-                android:scaleType="centerCrop"
-                android:src="@drawable/ic_recipe_sample" />
+                android:scaleType="center"
+                android:src="@drawable/ic_loading_image" />
 
         </androidx.cardview.widget.CardView>
 


### PR DESCRIPTION
## 무슨 기능인가요?
- 레시피 탐구 탭 UI 수정

## 화면
<img width="40%" src="https://user-images.githubusercontent.com/40855422/147873254-45b9cde9-fac9-4625-986f-a9814f78cffb.png"/> <img width="40%" src="https://user-images.githubusercontent.com/40855422/147873256-69b58428-dc49-4812-8811-ec32ea07182d.png"/>

## 구체적인 작업 내용
- 전체 화면 스크롤 설정
  - recycler view만 따로 스크롤되던 부분을 없앴습니다.
- 모드 변경 시 랭킹 메달 아이콘이 사라지는 오류 해결
- 이미지 로딩 전/실패 시 기본 이미지 설정
  - `ic_loading_image`의 크기가 작기 때문에 scaleType을 `centerCrop`이 아닌 `center`로 설정했습니다.

## 기타

## Close Issue
close #105 